### PR TITLE
Fix broken tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
-AbstractGPs = "0.2.21"
+AbstractGPs = "0.2.25"
 BlockArrays = "0.15"
 ChainRulesCore = "0.9"
 Distributions = "0.19, 0.20, 0.21, 0.22, 0.23, 0.24"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Stheno"
 uuid = "8188c328-b5d6-583d-959b-9690869a5511"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -21,9 +21,9 @@ As such, we have the following functions in addition to the AbstractGPs API impl
 
 | Function | Brief description |
 |:--------------------- |:---------------------- |
-| `cov_diag(f, x)` | `diag(cov(f, x))` |
-| `cov_diag(f, x, x′)` | `diag(cov(f, x, x′))` |
-| `cov_diag(f, f′, x, x′)` | `diag(cov(f, f′, x, x′))` |
+| `var(f, x)` | `diag(cov(f, x))` |
+| `var(f, x, x′)` | `diag(cov(f, x, x′))` |
+| `var(f, f′, x, x′)` | `diag(cov(f, f′, x, x′))` |
 
 The second and third rows of the table only make sense when `length(x) == length(x′)`, of course.
 

--- a/src/Stheno.jl
+++ b/src/Stheno.jl
@@ -20,13 +20,15 @@ module Stheno
     import AbstractGPs:
         mean,
         cov,
-        cov_diag,
+        var,
         mean_and_cov,
-        mean_and_cov_diag,
+        mean_and_var,
         rand,
         logpdf,
         elbo,
-        dtc
+        dtc,
+        posterior,
+        approx_posterior
 
     using MacroTools: @capture, combinedef, postwalk, splitdef
 
@@ -74,4 +76,5 @@ module Stheno
     export wrap, BlockData, GPC, GPPPInput, @gppp
     export elbo, dtc
     export ∘, select, stretch, periodic, shift
+    export cov_diag, mean_and_cov_diag
 end # module

--- a/src/abstract_gp.jl
+++ b/src/abstract_gp.jl
@@ -2,14 +2,9 @@
 abstract type SthenoAbstractGP <: AbstractGP end
 
 # TYPE-PIRACY
-function AbstractGPs.cov_diag(f::GP, x::AbstractVector, x′::AbstractVector)
+function var(f::GP, x::AbstractVector, x′::AbstractVector)
     return kernelmatrix_diag(f.kernel, x, x′)
 end
-
-# Implement some of the AbstractGPs API for all of the GPs in this package.
-mean_and_cov(f::SthenoAbstractGP, x::AbstractVector) = (mean(f, x), cov(f, x))
-
-mean_and_cov_diag(f::SthenoAbstractGP, x::AbstractVector) = (mean(f, x), cov_diag(f, x))
 
 # Ensure that this package gets to handle the covariance between its own GPs.
 # AbstractGPs doesn't support this in general because it's unclear how it ought to be

--- a/src/composite/addition.jl
+++ b/src/composite/addition.jl
@@ -24,21 +24,15 @@ mean((_, fa, fb)::add_args, x::AV) = mean(fa, x) .+ mean(fb, x)
 function cov((_, fa, fb)::add_args, x::AV)
     return cov(fa, x) .+ cov(fb, x) .+ cov(fa, fb, x, x) .+ cov(fb, fa, x, x)
 end
-function cov_diag((_, fa, fb)::add_args, x::AV)
-    return +(
-        cov_diag(fa, x), cov_diag(fb, x),
-        cov_diag(fa, fb, x, x), cov_diag(fb, fa, x, x),
-    )
+function var((_, fa, fb)::add_args, x::AV)
+    return var(fa, x) .+ var(fb, x) .+ var(fa, fb, x, x) .+ var(fb, fa, x, x)
 end
 
 function cov((_, fa, fb)::add_args, x::AV, x′::AV)
     return cov(fa, x, x′) .+ cov(fb, x, x′) .+ cov(fa, fb, x, x′) .+ cov(fb, fa, x, x′)
 end
-function cov_diag((_, fa, fb)::add_args, x::AV, x′::AV)
-    return +(
-        cov_diag(fa, x, x′), cov_diag(fb, x, x′),
-        cov_diag(fa, fb, x, x′), cov_diag(fb, fa, x, x′),
-    )
+function var((_, fa, fb)::add_args, x::AV, x′::AV)
+    return var(fa, x, x′) .+ var(fb, x, x′) .+ var(fa, fb, x, x′) .+ var(fb, fa, x, x′)
 end
 
 function cov((_, fa, fb)::add_args, f′::AbstractGP, x::AV, x′::AV)
@@ -48,11 +42,11 @@ function cov(f::AbstractGP, (_, fa, fb)::add_args, x::AV, x′::AV)
     return cov(f, fa, x, x′) .+ cov(f, fb, x, x′)
 end
 
-function cov_diag((_, fa, fb)::add_args, f′::AbstractGP, x::AV, x′::AV)
-    return cov_diag(fa, f′, x, x′) .+ cov_diag(fb, f′, x, x′)
+function var((_, fa, fb)::add_args, f′::AbstractGP, x::AV, x′::AV)
+    return var(fa, f′, x, x′) .+ var(fb, f′, x, x′)
 end
-function cov_diag(f::AbstractGP, (_, fa, fb)::add_args, x::AV, x′::AV)
-    return cov_diag(f, fa, x, x′) .+ cov_diag(f, fb, x, x′)
+function var(f::AbstractGP, (_, fa, fb)::add_args, x::AV, x′::AV)
+    return var(f, fa, x, x′) .+ var(f, fb, x, x′)
 end
 
 
@@ -72,13 +66,13 @@ mean((_, b, f)::add_known, x::AV) = b.(x) .+ mean(f, x)
 mean((_, b, f)::add_known{<:Real}, x::AV) = b .+ mean(f, x)
 
 cov((_, b, f)::add_known, x::AV) = cov(f, x)
-cov_diag((_, b, f)::add_known, x::AV) = cov_diag(f, x)
+var((_, b, f)::add_known, x::AV) = var(f, x)
 
 cov((_, b, f)::add_known, x::AV, x′::AV) = cov(f, x, x′)
-cov_diag((_, b, f)::add_known, x::AV, x′::AV) = cov_diag(f, x, x′)
+var((_, b, f)::add_known, x::AV, x′::AV) = var(f, x, x′)
 
 cov((_, b, f)::add_known, f′::AbstractGP, x::AV, x′::AV) = cov(f, f′, x, x′)
 cov(f::AbstractGP, (_, b, f′)::add_known, x::AV, x′::AV) = cov(f, f′, x, x′)
 
-cov_diag((_, b, f)::add_known, f′::AbstractGP, x::AV, x′::AV) = cov_diag(f, f′, x, x′)
-cov_diag(f::AbstractGP, (_, b, f′)::add_known, x::AV, x′::AV) = cov_diag(f, f′, x, x′)
+var((_, b, f)::add_known, f′::AbstractGP, x::AV, x′::AV) = var(f, f′, x, x′)
+var(f::AbstractGP, (_, b, f′)::add_known, x::AV, x′::AV) = var(f, f′, x, x′)

--- a/src/composite/compose.jl
+++ b/src/composite/compose.jl
@@ -13,16 +13,16 @@ const comp_args = Tuple{typeof(∘), AbstractGP, Any}
 mean((_, f, g)::comp_args, x::AV) = mean(f, g.(x))
 
 cov((_, f, g)::comp_args, x::AV) = cov(f, g.(x))
-cov_diag((_, f, g)::comp_args, x::AV) = cov_diag(f, g.(x))
+var((_, f, g)::comp_args, x::AV) = var(f, g.(x))
 
 cov((_, f, g)::comp_args, x::AV, x′::AV) = cov(f, g.(x), g.(x′))
-cov_diag((_, f, g)::comp_args, x::AV, x′::AV) = cov_diag(f, g.(x), g.(x′))
+var((_, f, g)::comp_args, x::AV, x′::AV) = var(f, g.(x), g.(x′))
 
 cov((_, f, g)::comp_args, f′::AbstractGP, x::AV, x′::AV) = cov(f, f′, g.(x), x′)
 cov(f::AbstractGP, (_, f′, g)::comp_args, x::AV, x′::AV) = cov(f, f′, x, g.(x′))
 
-cov_diag((_, f, g)::comp_args, f′::AbstractGP, x::AV, x′::AV) = cov_diag(f, f′, g.(x), x′)
-cov_diag(f::AbstractGP, (_, f′, g)::comp_args, x::AV, x′::AV) = cov_diag(f, f′, x, g.(x′))
+var((_, f, g)::comp_args, f′::AbstractGP, x::AV, x′::AV) = var(f, f′, g.(x), x′)
+var(f::AbstractGP, (_, f′, g)::comp_args, x::AV, x′::AV) = var(f, f′, x, g.(x′))
 
 
 """

--- a/src/composite/composite_gp.jl
+++ b/src/composite/composite_gp.jl
@@ -19,10 +19,10 @@ CompositeGP(args::Targs, gpc::GPC) where {Targs} = CompositeGP{Targs}(args, gpc)
 mean(f::CompositeGP, x::AbstractVector) = mean(f.args, x)
 
 cov(f::CompositeGP, x::AbstractVector) = cov(f.args, x)
-cov_diag(f::CompositeGP, x::AbstractVector) = cov_diag(f.args, x)
+var(f::CompositeGP, x::AbstractVector) = var(f.args, x)
 
 cov(f::CompositeGP, x::AbstractVector, x′::AbstractVector) = cov(f.args, x, x′)
-cov_diag(f::CompositeGP, x::AbstractVector, x′::AbstractVector) = cov_diag(f.args, x, x′)
+var(f::CompositeGP, x::AbstractVector, x′::AbstractVector) = var(f.args, x, x′)
 
 function cov(
     f::SthenoAbstractGP, f′::SthenoAbstractGP, x::AbstractVector, x′::AbstractVector,
@@ -39,17 +39,17 @@ function cov(
     end
 end
 
-function cov_diag(
+function var(
     f::SthenoAbstractGP, f′::SthenoAbstractGP, x::AbstractVector, x′::AbstractVector,
 )
     @assert f.gpc === f′.gpc
     if f.n === f′.n
-        return cov_diag(f.args, x, x′)
+        return var(f.args, x, x′)
     elseif f isa WrappedGP && f.n > f′.n || f′ isa WrappedGP && f′.n > f.n
         return zeros(length(x))
     elseif f.n >= f′.n
-        return cov_diag(f.args, f′, x, x′)
+        return var(f.args, f′, x, x′)
     else
-        return cov_diag(f, f′.args, x, x′)
+        return var(f, f′.args, x, x′)
     end
 end

--- a/src/composite/cross.jl
+++ b/src/composite/cross.jl
@@ -27,8 +27,8 @@ function cov((_, fs)::cross_args, x::BlockData)
     return Array(mortar(reshape(Cs, :, 1)))
 end
 
-function cov_diag((_, fs)::cross_args, x::BlockData)
-    cs = map(cov_diag, fs, blocks(x))
+function var((_, fs)::cross_args, x::BlockData)
+    cs = map(var, fs, blocks(x))
     return Array(mortar(cs))
 end
 
@@ -37,8 +37,8 @@ function cov((_, fs)::cross_args, x::BlockData, x′::BlockData)
     return Array(mortar(reshape(Cs, :, 1)))
 end
 
-function cov_diag((_, fs)::cross_args, x::BlockData, x′::BlockData)
-    cs = map(cov_diag, fs, blocks(x), blocks(x′))
+function var((_, fs)::cross_args, x::BlockData, x′::BlockData)
+    cs = map(var, fs, blocks(x), blocks(x′))
     return Array(mortar(cs))
 end
 
@@ -51,10 +51,10 @@ function cov(f::AbstractGP, (_, fs)::cross_args, x::AV, x′::BlockData)
     return Array(mortar(Cs))
 end
 
-function cov_diag(args::cross_args, f′::AbstractGP, x::BlockData, x′::AV)
+function var(args::cross_args, f′::AbstractGP, x::BlockData, x′::AV)
     return diag(cov(args, f′, x, x′))
 end
-function cov_diag(f::AbstractGP, args::cross_args, x::AV, x′::BlockData)
+function var(f::AbstractGP, args::cross_args, x::AV, x′::BlockData)
     return diag(cov(f, args, x, x′))
 end
 

--- a/src/composite/product.jl
+++ b/src/composite/product.jl
@@ -24,23 +24,23 @@ function cov((_, σ, g)::prod_args, x::AV)
     σx = σ.(x)
     return σx .* cov(g, x) .* σx'
 end
-cov_diag((_, σ, g)::prod_args, x::AV) = σ.(x).^2 .* cov_diag(g, x)
+var((_, σ, g)::prod_args, x::AV) = σ.(x).^2 .* var(g, x)
 
 function cov((_, σ, g)::prod_args, x::AV, x′::AV)
     return σ.(x) .* cov(g, x, x′) .* σ.(x′)'
 end
-function cov_diag((_, σ, g)::prod_args, x::AV, x′::AV)
-    return σ.(x) .* cov_diag(g, x, x′) .* σ.(x′)
+function var((_, σ, g)::prod_args, x::AV, x′::AV)
+    return σ.(x) .* var(g, x, x′) .* σ.(x′)
 end
 
 cov((_, σ, f)::prod_args, f′::AbstractGP, x::AV, x′::AV) = σ.(x) .* cov(f, f′, x, x′)
 cov(f::AbstractGP, (_, σ, f′)::prod_args, x::AV, x′::AV) = cov(f, f′, x, x′) .* (σ.(x′))'
 
-function cov_diag((_, σ, f)::prod_args, f′::AbstractGP, x::AV, x′::AV)
-    return σ.(x) .* cov_diag(f, f′, x, x′)
+function var((_, σ, f)::prod_args, f′::AbstractGP, x::AV, x′::AV)
+    return σ.(x) .* var(f, f′, x, x′)
 end
-function cov_diag(f::AbstractGP, (_, σ, f′)::prod_args, x::AV, x′::AV)
-    return cov_diag(f, f′, x, x′) .* σ.(x′)
+function var(f::AbstractGP, (_, σ, f′)::prod_args, x::AV, x′::AV)
+    return var(f, f′, x, x′) .* σ.(x′)
 end
 
 #
@@ -50,19 +50,19 @@ end
 mean((_, σ, g)::prod_args{<:Real}, x::AV) = σ .* mean(g, x)
 
 cov((_, σ, g)::prod_args{<:Real}, x::AV) = (σ^2) .* cov(g, x)
-cov_diag((_, σ, g)::prod_args{<:Real}, x::AV) = (σ^2) .* cov_diag(g, x)
+var((_, σ, g)::prod_args{<:Real}, x::AV) = (σ^2) .* var(g, x)
 
 cov((_, σ, g)::prod_args{<:Real}, x::AV, x′::AV) = (σ^2) .* cov(g, x, x′)
-cov_diag((_, σ, g)::prod_args{<:Real}, x::AV, x′::AV) = (σ^2) .* cov_diag(g, x, x′)
+var((_, σ, g)::prod_args{<:Real}, x::AV, x′::AV) = (σ^2) .* var(g, x, x′)
 
 cov((_, σ, f)::prod_args{<:Real}, f′::AbstractGP, x::AV, x′::AV) = σ .* cov(f, f′, x, x′)
 cov(f::AbstractGP, (_, σ, f′)::prod_args{<:Real}, x::AV, x′::AV) = cov(f, f′, x, x′) .* σ
 
-function cov_diag((_, σ, f)::prod_args{<:Real}, f′::AbstractGP, x::AV, x′::AV)
-    return σ .* cov_diag(f, f′, x, x′)
+function var((_, σ, f)::prod_args{<:Real}, f′::AbstractGP, x::AV, x′::AV)
+    return σ .* var(f, f′, x, x′)
 end
-function cov_diag(f::AbstractGP, (_, σ, f′)::prod_args{<:Real}, x::AV, x′::AV)
-    return cov_diag(f, f′, x, x′) .* σ
+function var(f::AbstractGP, (_, σ, f′)::prod_args{<:Real}, x::AV, x′::AV)
+    return var(f, f′, x, x′) .* σ
 end
 
 # Use multiplication to define the negation of a GP

--- a/src/gaussian_process_probabilistic_programme.jl
+++ b/src/gaussian_process_probabilistic_programme.jl
@@ -59,41 +59,41 @@ function extract_components(f::GPPP, x::BlockData)
     return cross(fs), BlockData(vs)
 end
 
-function AbstractGPs.mean(f::GPPP, x::AbstractVector)
+function mean(f::GPPP, x::AbstractVector)
     fs, vs = extract_components(f, x)
     return mean(fs, vs)
 end
 
-function AbstractGPs.cov(f::GPPP, x::AbstractVector)
+function cov(f::GPPP, x::AbstractVector)
     fs, vs = extract_components(f, x)
     return cov(fs, vs)
 end
 
-function AbstractGPs.cov_diag(f::GPPP, x::AbstractVector)
+function var(f::GPPP, x::AbstractVector)
     fs, vs = extract_components(f, x)
-    return cov_diag(fs, vs)
+    return var(fs, vs)
 end
 
-function AbstractGPs.cov(f::GPPP, x::AbstractVector, x′::AbstractVector)
+function cov(f::GPPP, x::AbstractVector, x′::AbstractVector)
     fs_x, vs_x = extract_components(f, x)
     fs_x′, vs_x′ = extract_components(f, x′)
     return cov(fs_x, fs_x′, vs_x, vs_x′)
 end
 
-function AbstractGPs.cov_diag(f::GPPP, x::AbstractVector, x′::AbstractVector)
+function var(f::GPPP, x::AbstractVector, x′::AbstractVector)
     fs_x, vs_x = extract_components(f, x)
     fs_x′, vs_x′ = extract_components(f, x′)
-    return cov_diag(fs_x, fs_x′, vs_x, vs_x′)
+    return var(fs_x, fs_x′, vs_x, vs_x′)
 end
 
-function AbstractGPs.mean_and_cov(f::GPPP, x::AbstractVector)
+function mean_and_cov(f::GPPP, x::AbstractVector)
     fs, vs = extract_components(f, x)
     return mean_and_cov(fs, vs)
 end
 
-function AbstractGPs.mean_and_cov_diag(f::GPPP, x::AbstractVector)
+function mean_and_var(f::GPPP, x::AbstractVector)
     fs, vs = extract_components(f, x)
-    return mean_and_cov_diag(fs, vs)
+    return mean_and_var(fs, vs)
 end
 
 

--- a/src/gp/gp.jl
+++ b/src/gp/gp.jl
@@ -24,14 +24,14 @@ wrap(gp::Tgp, gpc::GPC) where {Tgp<:GP} = WrappedGP{Tgp}(gp, gpc)
 mean(f::WrappedGP, x::AbstractVector) = mean(f.gp, x)
 
 cov(f::WrappedGP, x::AbstractVector) = cov(f.gp, x)
-cov_diag(f::WrappedGP, x::AbstractVector) = cov_diag(f.gp, x)
+var(f::WrappedGP, x::AbstractVector) = var(f.gp, x)
 
 cov(f::WrappedGP, x::AbstractVector, x′::AbstractVector) = cov(f.gp, x, x′)
-cov_diag(f::WrappedGP, x::AbstractVector, x′::AbstractVector) = cov_diag(f.gp, x, x′)
+var(f::WrappedGP, x::AbstractVector, x′::AbstractVector) = var(f.gp, x, x′)
 
 function cov(f::WrappedGP, f′::WrappedGP, x::AbstractVector, x′::AbstractVector)
     return f === f′ ? cov(f, x, x′) : zeros(length(x), length(x′))
 end
-function cov_diag(f::WrappedGP, f′::WrappedGP, x::AbstractVector, x′::AbstractVector)
-    return f === f′ ? cov_diag(f, x, x′) : zeros(length(x))
+function var(f::WrappedGP, f′::WrappedGP, x::AbstractVector, x′::AbstractVector)
+    return f === f′ ? var(f, x, x′) : zeros(length(x))
 end

--- a/src/sparse_finite_gp.jl
+++ b/src/sparse_finite_gp.jl
@@ -40,29 +40,29 @@ end
 
 Base.length(f::SparseFiniteGP) = length(f.fobs)
 
-AbstractGPs.mean(f::SparseFiniteGP) = mean(f.fobs)
+mean(f::SparseFiniteGP) = mean(f.fobs)
 
 const __covariance_error = "The covariance matrix of a sparse GP can often be dense and " *
     "can cause the computer to run out of memory. If you are sure you have enough " *
     "memory, you can use `cov(f.fobs)`."
 
-AbstractGPs.cov(f::SparseFiniteGP) = error(__covariance_error)
+cov(f::SparseFiniteGP) = error(__covariance_error)
 
-AbstractGPs.marginals(f::SparseFiniteGP) = marginals(f.fobs)
+marginals(f::SparseFiniteGP) = marginals(f.fobs)
 
-AbstractGPs.rand(rng::AbstractRNG, f::SparseFiniteGP, N::Int) = rand(rng, f.fobs, N)
-AbstractGPs.rand(f::SparseFiniteGP, N::Int) = rand(Random.GLOBAL_RNG, f, N)
-AbstractGPs.rand(rng::AbstractRNG, f::SparseFiniteGP) = vec(rand(rng, f, 1))
-AbstractGPs.rand(f::SparseFiniteGP) = vec(rand(f, 1))
+rand(rng::AbstractRNG, f::SparseFiniteGP, N::Int) = rand(rng, f.fobs, N)
+rand(f::SparseFiniteGP, N::Int) = rand(Random.GLOBAL_RNG, f, N)
+rand(rng::AbstractRNG, f::SparseFiniteGP) = vec(rand(rng, f, 1))
+rand(f::SparseFiniteGP) = vec(rand(f, 1))
 
-AbstractGPs.elbo(f::SparseFiniteGP, y::AV{<:Real}) = elbo(f.fobs, y, f.finducing)
+elbo(f::SparseFiniteGP, y::AV{<:Real}) = elbo(f.fobs, y, f.finducing)
 
-AbstractGPs.logpdf(f::SparseFiniteGP, y::AV{<:Real}) = elbo(f.fobs, y, f.finducing)
+logpdf(f::SparseFiniteGP, y::AV{<:Real}) = elbo(f.fobs, y, f.finducing)
 
-function AbstractGPs.logpdf(f::SparseFiniteGP, Y::AbstractMatrix{<:Real})
+function logpdf(f::SparseFiniteGP, Y::AbstractMatrix{<:Real})
     return map(y -> logpdf(f, y), eachcol(Y))
 end
 
-function AbstractGPs.posterior(f::SparseFiniteGP, y::AbstractVector{<:Real})
-    return AbstractGPs.approx_posterior(AbstractGPs.VFE(), f.fobs, y, f.finducing)
+function posterior(f::SparseFiniteGP, y::AbstractVector{<:Real})
+    return approx_posterior(AbstractGPs.VFE(), f.fobs, y, f.finducing)
 end

--- a/test/abstract_gp.jl
+++ b/test/abstract_gp.jl
@@ -19,8 +19,8 @@ end
         @test cov(fx) == cov(f, x)
         @test cov(fx, fx′) == cov(f, x, x′)
         @test mean.(marginals(fx)) == mean(f(x))
-        @test var.(marginals(fx)) == cov_diag(f, x)
-        @test std.(marginals(fx)) == sqrt.(cov_diag(f, x))
+        @test var.(marginals(fx)) == var(f, x)
+        @test std.(marginals(fx)) == sqrt.(var(f, x))
     end
     @testset "rand (deterministic)" begin
         rng, N, D = MersenneTwister(123456), 10, 2

--- a/test/composite/test_util.jl
+++ b/test/composite/test_util.jl
@@ -161,10 +161,10 @@ function standard_1D_tests(rng::AbstractRNG, θ, f, x::AV, z::AV)
 
     @test cov(g, x) ≈ cov(g, x)'
     @test minimum(eigvals(cov(g, x))) > -1e-9
-    @test cov_diag(g, x) ≈ diag(cov(g, x))
+    @test var(g, x) ≈ diag(cov(g, x))
 
     @test cov(g, g, x, x) ≈ cov(g, x)
-    @test cov_diag(g, g, x, x) ≈ diag(cov(g, g, x, x))
+    @test var(g, g, x, x) ≈ diag(cov(g, g, x, x))
 
     standard_1D_dense_test(rng, θ, f, x, z)
     standard_1D_diag_test(rng, θ, f, x, z)

--- a/test/gaussian_process_probabilistic_programme.jl
+++ b/test/gaussian_process_probabilistic_programme.jl
@@ -36,7 +36,7 @@
         @test cov(f3, x1.x) == cov(f, x1)
 
         @test cov(f1, f3, x0.x, x1.x) == cov(f, x0, x1)
-        @test cov_diag(f3, f1, x1.x, x0.x) == cov_diag(f, x1, x0)
+        @test var(f3, f1, x1.x, x0.x) == var(f, x1, x0)
 
         y = rand(f(x1))
         @test cov(posterior(f3(x1.x), y)(x1.x)) == cov(posterior(f(x1), y)(x1))
@@ -85,14 +85,14 @@
         @test K_x0_x1 isa AbstractMatrix{<:Real}
         @test size(K_x0_x1) == (length(x0), length(x1))
 
-        # Check that single-process binary cov_diag is consistent.
-        K_x0_x0_diag = cov_diag(f, x0, x0)
+        # Check that single-process binary var is consistent.
+        K_x0_x0_diag = var(f, x0, x0)
         @test K_x0_x0_diag isa AbstractVector{<:Real}
         @test length(K_x0_x0_diag) == length(x0)
         @test K_x0_x0_diag ≈ diag(cov(f, x0, x0)) atol=atol rtol=rtol
 
-        # Check that unary cov_diag conforms to the API and is consistent with unary cov
-        K_x0_diag = cov_diag(f, x0)
+        # Check that unary var conforms to the API and is consistent with unary cov
+        K_x0_diag = var(f, x0)
         @test K_x0_diag isa AbstractVector{<:Real}
         @test length(K_x0_diag) == length(x0)
         @test K_x0_diag ≈ diag(cov(f, x0)) atol=atol rtol=rtol

--- a/test/gp/gp.jl
+++ b/test/gp/gp.jl
@@ -13,7 +13,7 @@ using Stheno: GPC
 
         @test mean(f, x) == AbstractGPs._map(m, x)
         @test cov(f, x) == kernelmatrix(k, x)
-        @test cov_diag(f, x) == diag(cov(f, x))
+        @test var(f, x) == diag(cov(f, x))
         @test cov(f, x, x) == kernelmatrix(k, x, x)
         @test cov(f, x, x′) == kernelmatrix(k, x, x′)
         @test cov(f, x, x′) ≈ cov(f, x′, x)'
@@ -34,7 +34,7 @@ using Stheno: GPC
         @test mean(f2, x) == AbstractGPs._map(m2, x)
 
         @test cov(f1, f2, x, x′) == zeros(N, N′)
-        @test cov_diag(f1, x) == ones(N)
+        @test var(f1, x) == ones(N)
 
         @test cov(f1, f1, x′, x) ≈ cov(f1, f1, x, x′)'
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using Test
 using TimerOutputs
 using Zygote
 
-using Stheno: mean, cov, cov_diag, GPC, AV
+using Stheno: mean, cov, var, GPC, AV
 
 const to = TimerOutput()
 

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -150,21 +150,21 @@ function abstractgp_interface_tests(
     @test size(K_x0_x1) == (length(x0), length(x1))
     @test K_x0_x1 ≈ cov(f, f, x0, x1)
 
-    # Check that binary cov_diag conforms to the API and is consistent with binary cov
-    K_x0_x3_diag = cov_diag(f, f′, x0, x3)
+    # Check that binary var conforms to the API and is consistent with binary cov
+    K_x0_x3_diag = var(f, f′, x0, x3)
     @test K_x0_x3_diag isa AbstractVector{<:Real}
     @test length(K_x0_x3_diag) == length(x0)
     @test K_x0_x3_diag ≈ diag(cov(f, f′, x0, x3)) atol=atol rtol=rtol
-    @test K_x0_x3_diag ≈ cov_diag(f′, f, x3, x0) atol=atol rtol=rtol
+    @test K_x0_x3_diag ≈ var(f′, f, x3, x0) atol=atol rtol=rtol
 
-    # Check that unary-binary cov_diag is consistent.
-    K_x0_x0_diag = cov_diag(f, x0, x0)
+    # Check that unary-binary var is consistent.
+    K_x0_x0_diag = var(f, x0, x0)
     @test K_x0_x0_diag isa AbstractVector{<:Real}
     @test length(K_x0_x0_diag) == length(x0)
     @test K_x0_x0_diag ≈ diag(cov(f, x0, x0)) atol=atol rtol=rtol
 
-    # Check that unary cov_diag conforms to the API and is consistent with unary cov
-    K_x0_diag = cov_diag(f, x0)
+    # Check that unary var conforms to the API and is consistent with unary cov
+    K_x0_diag = var(f, x0)
     @test K_x0_diag isa AbstractVector{<:Real}
     @test length(K_x0_diag) == length(x0)
     @test K_x0_diag ≈ diag(cov(f, x0)) atol=atol rtol=rtol


### PR DESCRIPTION
A patch release of AbstractGPs did actually break some tests, because doctests are sensitive to deprecation warnings.