### PR TITLE
Import `marginals`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Stheno"
 uuid = "8188c328-b5d6-583d-959b-9690869a5511"
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/Stheno.jl
+++ b/src/Stheno.jl
@@ -28,7 +28,8 @@ module Stheno
         elbo,
         dtc,
         posterior,
-        approx_posterior
+        approx_posterior,
+        marginals
 
     using MacroTools: @capture, combinedef, postwalk, splitdef
 

--- a/test/sparse_finite_gp.jl
+++ b/test/sparse_finite_gp.jl
@@ -18,6 +18,7 @@
         fx = f(x)
         fxu = SparseFiniteGP(f(x), f(xu))
         @test mean(fxu) == mean(fx)
+        @test marginals(fxu) == marginals(fx)
         @test rand(MersenneTwister(12345), fxu) == rand(MersenneTwister(12345), fx)
         @test_throws ErrorException(covariance_error) cov(fxu)
         @test cov(fxu.fobs) == cov(fx)


### PR DESCRIPTION
I guess you actually want to import `AbstractGPs.marginals` or qualify the definition in https://github.com/JuliaGaussianProcesses/Stheno.jl/blob/b4e2d20f973a0816272fdf07bdd5896a614b99e1/src/sparse_finite_gp.jl#L51. I assume this causes the problem reported in https://discourse.julialang.org/t/stheno-marginals/58943.