### PR TITLE
Finish GPPP inputs implementations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Stheno"
 uuid = "8188c328-b5d6-583d-959b-9690869a5511"
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/gaussian_process_probabilistic_programme.jl
+++ b/src/gaussian_process_probabilistic_programme.jl
@@ -54,9 +54,8 @@ Base.getindex(x::GPPPInput, idx) = map(x_ -> (x.p, x_), x.x[idx])
 extract_components(f::GPPP, x::GPPPInput) = f.fs[x.p], x.x
 
 function extract_components(f::GPPP, x::BlockData)
-    fs = map(v -> f.fs[v.p], x.X)
-    vs = map(v -> v.x, x.X)
-    return cross(fs), BlockData(vs)
+    fs_and_vs = map(x_ -> extract_components(f, x_), x.X)
+    return cross(first.(fs_and_vs)), BlockData(last.(fs_and_vs))
 end
 
 function extract_components(f::GPPP, x::AbstractVector{<:Tuple{T, V}} where {T, V})

--- a/test/gaussian_process_probabilistic_programme.jl
+++ b/test/gaussian_process_probabilistic_programme.jl
@@ -77,6 +77,10 @@
             collect(BlockData([GPPPInput(:f2, randn(3)), GPPPInput(:f3, randn(2))])),
             GPPPInput(:f1, randn(4)),
         ),
+        (
+            BlockData([collect(GPPPInput(:f2, randn(3))), GPPPInput(:f3, randn(2))]),
+            GPPPInput(:f1, randn(4)),
+        ),
     ]
 
         atol=1e-9

--- a/test/gaussian_process_probabilistic_programme.jl
+++ b/test/gaussian_process_probabilistic_programme.jl
@@ -24,7 +24,7 @@
     f = Stheno.GPPP((f1 = f1, f2 = f2, f3 = f3), gpc)
 
     # The same answers should be obtained manually or via the GPPP.
-    @testset "External Consistency" begin
+    @timedtestset "External Consistency" begin
 
         x0 = GPPPInput(:f1, randn(4))
         x1 = GPPPInput(:f3, randn(3))
@@ -60,6 +60,22 @@
         (
             BlockData([GPPPInput(:f2, randn(3)), GPPPInput(:f3, randn(2))]),
             BlockData([GPPPInput(:f1, randn(6))]),
+        ),
+        (
+            collect(GPPPInput(:f1, randn(4))),
+            collect(GPPPInput(:f3, randn(3))),
+        ),
+        (
+            GPPPInput(:f1, randn(4)),
+            collect(GPPPInput(:f3, randn(3))),
+        ),
+        (
+            collect(BlockData([GPPPInput(:f2, randn(3)), GPPPInput(:f3, randn(2))])),
+            collect(GPPPInput(:f1, randn(4))),
+        ),
+        (
+            collect(BlockData([GPPPInput(:f2, randn(3)), GPPPInput(:f3, randn(2))])),
+            GPPPInput(:f1, randn(4)),
         ),
     ]
 
@@ -98,7 +114,7 @@
         @test K_x0_diag ≈ diag(cov(f, x0)) atol=atol rtol=rtol
     end
 
-    @testset "gppp macro" begin
+    @timedtestset "gppp macro" begin
 
         # Declare a GPPP using the helper functionality.
         f = @gppp let


### PR DESCRIPTION
This PR enables a GPPP to be indexed using any `AbstractVector{Tuple{Symbol, T}}`.