### PR TITLE
Upgrade ZygoteRules to ChainRules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Stheno"
 uuid = "8188c328-b5d6-583d-959b-9690869a5511"
-version = "0.7.8"
+version = "0.7.9"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Stheno"
 uuid = "8188c328-b5d6-583d-959b-9690869a5511"
-version = "0.7.9"
+version = "0.7.10"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/src/Stheno.jl
+++ b/src/Stheno.jl
@@ -31,8 +31,6 @@ module Stheno
 
     using MacroTools: @capture, combinedef, postwalk, splitdef
 
-    using ZygoteRules: @adjoint
-
     const AV{T} = AbstractVector{T}
 
     # Various bits of utility that aren't inherently GP-related. Often very type-piratic.

--- a/src/composite/compose.jl
+++ b/src/composite/compose.jl
@@ -78,7 +78,7 @@ function broadcasted(f::Select, x::AbstractVector{<:CartesianIndex})
 end
 
 function ChainRulesCore.rrule(::typeof(broadcasted), f::Select, x::AV{<:CartesianIndex})
-    return broadcasted(f, x), Δ->(NoTangent(), NoTangent(), Zero())
+    return broadcasted(f, x), Δ->(NoTangent(), NoTangent(), ZeroTangent())
 end
 
 function broadcasted(f::Select{<:Integer}, x::AV{<:CartesianIndex})

--- a/src/composite/cross.jl
+++ b/src/composite/cross.jl
@@ -19,36 +19,36 @@ const cross_args{T<:AbstractVector{<:AbstractGP}} = Tuple{typeof(cross), T}
 
 function mean((_, fs)::cross_args, x::BlockData)
     blks = map((f, blk)->mean(f, blk), fs, blocks(x))
-    return Array(mortar(blks))
+    return _collect(mortar(blks))
 end
 
 function cov((_, fs)::cross_args, x::BlockData)
     Cs = reshape(map((f, blk)->cov(f, (cross, fs), blk, x), fs, blocks(x)), :, 1)
-    return Array(mortar(reshape(Cs, :, 1)))
+    return _collect(mortar(reshape(Cs, :, 1)))
 end
 
 function var((_, fs)::cross_args, x::BlockData)
     cs = map(var, fs, blocks(x))
-    return Array(mortar(cs))
+    return _collect(mortar(cs))
 end
 
 function cov((_, fs)::cross_args, x::BlockData, x′::BlockData)
     Cs = reshape(map((f, blk)->cov(f, (cross, fs), blk, x′), fs, blocks(x)), :, 1)
-    return Array(mortar(reshape(Cs, :, 1)))
+    return _collect(mortar(reshape(Cs, :, 1)))
 end
 
 function var((_, fs)::cross_args, x::BlockData, x′::BlockData)
     cs = map(var, fs, blocks(x), blocks(x′))
-    return Array(mortar(cs))
+    return _collect(mortar(cs))
 end
 
 function cov((_, fs)::cross_args, f′::AbstractGP, x::BlockData, x′::AV)
     Cs = reshape(map((f, x)->cov(f, f′, x, x′), fs, blocks(x)), :, 1)
-    return Array(mortar(Cs))
+    return _collect(mortar(Cs))
 end
 function cov(f::AbstractGP, (_, fs)::cross_args, x::AV, x′::BlockData)
     Cs = reshape(map((f′, x′)->cov(f, f′, x, x′), fs, blocks(x′)), 1, :)
-    return Array(mortar(Cs))
+    return _collect(mortar(Cs))
 end
 
 function var(args::cross_args, f′::AbstractGP, x::BlockData, x′::AV)

--- a/src/util/block_arrays/dense.jl
+++ b/src/util/block_arrays/dense.jl
@@ -38,19 +38,13 @@ function ChainRulesCore.rrule(::typeof(BlockArrays.mortar), _blocks::AbstractArr
     return y, mortar_pullback  
 end
 
-function ChainRulesCore.rrule(::Type{<:Array}, X::BlockArray)
-    println("Hitting this rule")
+# A hook to which I can attach an rrule without commiting type-piracy against BlockArrays.
+_collect(X::BlockArray) = Array(X)
+
+function ChainRulesCore.rrule(::typeof(_collect), X::BlockArray)
     function Array_pullback(Δ::Array)
         ΔX = Tangent{Any}(blocks=BlockArray(Δ, axes(X)).blocks, axes=NoTangent())
         return (NoTangent(), ΔX)
-    end
-    return Array(X), Array_pullback
-end
-
-ZygoteRules.@adjoint function BlockArrays.Array(X::BlockArray)
-    function Array_pullback(Δ::Array)
-        ΔX = (blocks=BlockArray(Δ, axes(X)).blocks, axes=nothing)
-        return (ΔX,)
     end
     return Array(X), Array_pullback
 end

--- a/src/util/zygote_rules.jl
+++ b/src/util/zygote_rules.jl
@@ -1,8 +1,6 @@
 using Zygote
 import Zygote: accum
 
-const dtol = 1e-12 # threshold value for precise recalculation of distances
-
 function accum(D::Diagonal{T}, B::AbstractMatrix) where {T}
     A = Matrix{Union{T, Nothing}}(undef, size(D))
     A[diagind(A)] .= D.diag

--- a/test/util/block_arrays/dense.jl
+++ b/test/util/block_arrays/dense.jl
@@ -1,7 +1,7 @@
 @timedtestset "dense" begin
 
-    @testset "Array ∘ mortar" begin
-        @testset "BlockVector" begin
+    @timedtestset "Array ∘ mortar" begin
+        @timedtestset "BlockVector" begin
 
             # Generate some blocks.
             Ps = [5, 6, 7]
@@ -11,7 +11,7 @@
             ȳ = randn(sum(Ps))
             adjoint_test(Array ∘ mortar, ȳ, x)
         end
-        @testset "BlockMatrix" begin
+        @timedtestset "BlockMatrix" begin
 
             # Generate some blocks.
             Ps = [3, 4, 5]

--- a/test/util/block_arrays/dense.jl
+++ b/test/util/block_arrays/dense.jl
@@ -1,6 +1,6 @@
 @timedtestset "dense" begin
 
-    @timedtestset "Array ∘ mortar" begin
+    @timedtestset "Stheno._collect ∘ mortar" begin
         @timedtestset "BlockVector" begin
 
             # Generate some blocks.
@@ -9,7 +9,7 @@
 
             # Verify the pullback.
             ȳ = randn(sum(Ps))
-            adjoint_test(Array ∘ mortar, ȳ, x)
+            adjoint_test(Stheno._collect ∘ mortar, ȳ, x)
         end
         @timedtestset "BlockMatrix" begin
 
@@ -20,7 +20,7 @@
             Ȳ = randn(sum(Ps), sum(Qs))
 
             # Verify pullback.
-            adjoint_test(Array ∘ mortar, Ȳ, X)
+            adjoint_test(Stheno._collect ∘ mortar, Ȳ, X)
         end
     end
 end


### PR DESCRIPTION
There are some rules in Zygote.jl which are still getting in the way of ChainRules rules in Stheno.jl. These need to be removed before I can properly upgrade to ChainRules rules.

Rules that need to be moved from Zygote to ChainRules:
- [x] Array

edit: this PR upgrades some of the rules, not all of them though.